### PR TITLE
Replace OrientationEventListener with Broadcast Receiver for Screen Capture

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -23,9 +23,10 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
     }
+    namespace 'com.shamanec.stream'
 }
 
 dependencies {

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
-    package="com.shamanec.stream"
     android:versionCode="1"
     android:versionName="1.0">
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -10,7 +10,10 @@
     <uses-permission android:name="android.permission.INJECT_EVENTS"
         tools:ignore="ProtectedPermissions" />
 
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+
     <application
+        android:name=".GadsApp"
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
         android:label="GADS-Stream">

--- a/app/src/main/java/com/shamanec/stream/GadsApp.java
+++ b/app/src/main/java/com/shamanec/stream/GadsApp.java
@@ -1,0 +1,35 @@
+package com.shamanec.stream;
+
+import android.app.Application;
+import android.content.Intent;
+import android.content.res.Configuration;
+import android.util.Log;
+
+import static com.shamanec.stream.IntentActionConstants.ORIENTATION_CHANGED_ACTION;
+
+public class GadsApp extends Application {
+
+    private static final String TAG = "GadsApp";
+    private int lastKnownOrientation = Configuration.ORIENTATION_UNDEFINED;
+
+    @Override
+    public void onConfigurationChanged(Configuration newConfig) {
+        super.onConfigurationChanged(newConfig);
+        Log.d(TAG, "Configuration changed: " + newConfig.toString());
+
+        // Check if the orientation has actually changed
+        if (newConfig.orientation == lastKnownOrientation) {
+            Log.d(TAG, "Orientation did not change, skipping broadcast.");
+            return;
+        }
+
+        // Update the last known orientation
+        lastKnownOrientation = newConfig.orientation;
+
+        // Send the broadcast
+        Intent intent = new Intent(ORIENTATION_CHANGED_ACTION);
+        intent.setPackage(getPackageName());
+        sendBroadcast(intent);
+        Log.d(TAG, "Broadcast sent: " + ORIENTATION_CHANGED_ACTION);
+    }
+}

--- a/app/src/main/java/com/shamanec/stream/IntentActionConstants.java
+++ b/app/src/main/java/com/shamanec/stream/IntentActionConstants.java
@@ -1,0 +1,9 @@
+package com.shamanec.stream;
+
+public final class IntentActionConstants {
+
+    public static final String ORIENTATION_CHANGED_ACTION = "com.shamanec.stream.ORIENTATION_CHANGED";
+
+    private IntentActionConstants() {}
+
+}

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
-    id 'com.android.application' version '7.3.1' apply false
-    id 'com.android.library' version '7.3.1' apply false
+    id 'com.android.application' version '8.8.0' apply false
+    id 'com.android.library' version '8.8.0' apply false
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,3 +19,5 @@ android.useAndroidX=true
 # resources declared in the library itself and none from the library's dependencies,
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
+android.defaults.buildfeatures.buildconfig=true
+android.nonFinalResIds=false

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Thu Mar 02 10:05:18 EET 2023
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
This PR enhances the screen capture service by replacing the OrientationEventListener with a more efficient broadcast-based approach:

**Application Enhancements:**
  - Added a custom Application class (GadsApp.java) to detect onConfigurationChanged events.
  - Broadcasts ORIENTATION_CHANGED_ACTION whenever device orientation changes.

**Screen Capture Service Updates:**
  - Removed OrientationEventListener and replaced it with a BroadcastReceiver to listen for orientation changes.
  - Upon receiving an orientation change event, the service clears the image queue, updates rotation, and recreates the virtual display.
  - Ensures receiver registration with compatibility for Android API 26+ (Context.RECEIVER_NOT_EXPORTED).

**Permissions & Manifest Updates:**
  - Added POST_NOTIFICATIONS permission to support future notification features.

**Cleanup & Optimization:**
  - Removed redundant code, including an unused MD5 hashing method for bitmaps.